### PR TITLE
feat: add ssl options object

### DIFF
--- a/lib/interfaces/postgres-options.interface.ts
+++ b/lib/interfaces/postgres-options.interface.ts
@@ -8,7 +8,7 @@ export interface PostgresModuleOptions {
   password?: string;
   user?: string;
   port?: number;
-  ssl?: boolean;
+  ssl?: boolean | PostgresSSLOptions;
   connectionString?: string;
   retryAttempts?: number;
   retryDelay?: number;
@@ -19,4 +19,11 @@ export interface PostgresModuleOptions {
   applicationName?: string;
   connectionTimeoutMillis?: number;
   idleInTransactionSessionTimeout?: number;
+}
+
+interface PostgresSSLOptions {
+  rejectUnauthorized?: boolean;
+  ca?: string;
+  key?: string;
+  cert?: string;
 }


### PR DESCRIPTION
- Add support to connect to Postgres database with a self-signed cert

PG Usage: https://node-postgres.com/features/ssl#self-signed-cert